### PR TITLE
issu:50 :アクセスに失敗した際のロジックが正常に動作しない問題を解決

### DIFF
--- a/api/app/services/chat_gpt_api.rb
+++ b/api/app/services/chat_gpt_api.rb
@@ -21,6 +21,7 @@ class ChatGptApi
     @frequency_penalty = settings_list['frequency_penalty']
     @max_create = settings_list['max_create']
     @max_failed_access = settings_list['max_failed_access']
+    @time_to_access_refresh = settings_list['time_to_access_refresh']
 
     @client = OpenAI::Client.new(access_token: ENV['OPENAI_ACCESS_TOKEN'])
   end

--- a/api/spec/services/chat_gpt_api_spec.rb
+++ b/api/spec/services/chat_gpt_api_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe ChatGptApi, type: :unit do
       'presence_penalty' => 0.5,
       'frequency_penalty' => 0.5,
       'max_create' => 5,
-      'max_failed_access' => 3.0
+      'max_failed_access' => 3.0,
+      'time_to_access_refresh' => 3
     }
   end
 
@@ -36,6 +37,7 @@ RSpec.describe ChatGptApi, type: :unit do
       expect(chat_gpt_api.instance_variable_get(:@max_tokens)).to eq(100)
       expect(chat_gpt_api.instance_variable_get(:@presence_penalty)).to eq(0.5)
       expect(chat_gpt_api.instance_variable_get(:@frequency_penalty)).to eq(0.5)
+      expect(chat_gpt_api.instance_variable_get(:@time_to_access_refresh)).to eq(3)
     end
   end
 

--- a/api/spec/services/chat_gpt_api_spec.rb
+++ b/api/spec/services/chat_gpt_api_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ChatGptApi, type: :unit do
       'presence_penalty' => 0.5,
       'frequency_penalty' => 0.5,
       'max_create' => 5,
-      'max_failed_access' => 3.0,
+      'max_failed_access' => 3,
       'time_to_access_refresh' => 3
     }
   end


### PR DESCRIPTION
# 要件&設計
なし

# 何を?(What)
- ChatGPT APIにアクセスできなかった際のロジック
- time_to_access_refreshが正しく定義されてない
- テストケースがない

# 何の為に?(Why)
- ネットワークエラーの際にリトライするシステムを正常動作させたい
- テストケースで問題を検出できるようにしたい

# どうやって?(How)
- ChatGptApi#initializeで@time_to_access_refreshを定義
- 正常に遅延しているか検証するテストを作成

# 確認事項
- [x] テストケース'ネットワーク接続に規定回数失敗した場合、設定された遅延時間が経過してからFaraday::ConnectionFailedが発生する' の内容がWhyを満たしている
- [x] テストが全て通る