### PR TITLE
issue:55 :test: chatGptApiのinitializeのテストコードを修正

### DIFF
--- a/api/spec/services/chat_gpt_api_spec.rb
+++ b/api/spec/services/chat_gpt_api_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe ChatGptApi, type: :unit do
       expect(chat_gpt_api.instance_variable_get(:@max_tokens)).to eq(100)
       expect(chat_gpt_api.instance_variable_get(:@presence_penalty)).to eq(0.5)
       expect(chat_gpt_api.instance_variable_get(:@frequency_penalty)).to eq(0.5)
+      expect(chat_gpt_api.instance_variable_get(:@max_create)).to eq(5)
+      expect(chat_gpt_api.instance_variable_get(:@max_failed_access)).to eq(3)
       expect(chat_gpt_api.instance_variable_get(:@time_to_access_refresh)).to eq(3)
     end
   end


### PR DESCRIPTION
# 要件&設計

# 何を?(What)
-  ChatGptApi#initializeのテストコードに確認する変数を２つ追加

# 何の為に?(Why)
- 初期化できているか確認できていない変数が２つあったため

# どうやって?(How)
- `max_create`と`max_failed_access`について初期化できているかテストで確認

# 確認事項
- [x] テストの内容で要件&設計を満たしている
- [x] テストが全て通る
- [x] rubocopが通る